### PR TITLE
art-audio: Add realtime privileges.

### DIFF
--- a/kousu-art-audio/PKGBUILD
+++ b/kousu-art-audio/PKGBUILD
@@ -50,6 +50,9 @@ depends=(
   lmms
   #hydrogen # basic but effective drum sequencer
   #ft2-clone # tracker
+  #
+
+  realtime-privileges  # you also need your user to be in 'realtime'
 )
 
 optdepends=(


### PR DESCRIPTION
This is WIP because it would be good to figure out a way to make sure the 'realtime' group actually gets used. I can't set default groups. And once a user is created I can't add groups automatically. Maybe a /etc/motd.d warning to highlight it? If you log in and you aren't in it it reminds you to add yourself to it? That could be obnoxious but I don't know what else to do.