### PR TITLE
desktop: forget GPG and SSH credentials on screen lock.

### DIFF
--- a/kousu-desktop/kousu-desktop.install
+++ b/kousu-desktop/kousu-desktop.install
@@ -3,6 +3,8 @@
 _deploy() {
   systemctl enable bluetooth
   systemctl enable iwd
+
+  systemctl --global preset drop-credentials-on-screenlock
 }
 
 
@@ -19,4 +21,3 @@ post_upgrade() {
 pre_remove() {
   systemctl disable bluetooth # ???
 }
-

--- a/kousu-desktop/src/usr/lib/systemd/user-preset/10-drop-credentials-on-screenlock.preset
+++ b/kousu-desktop/src/usr/lib/systemd/user-preset/10-drop-credentials-on-screenlock.preset
@@ -1,0 +1,1 @@
+enable drop-credentials-on-screenlock.service

--- a/kousu-desktop/src/usr/lib/systemd/user/drop-credentials-on-screenlock.service
+++ b/kousu-desktop/src/usr/lib/systemd/user/drop-credentials-on-screenlock.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Screen lock credential-dropping monitor
+After=graphical-session.target
+
+[Service]
+Type=simple
+#ExecStartPre=systemctl --user import-environment SSH_AUTH_SOCK
+ExecStart=/usr/libexec/kousu-desktop/drop-credentials-on-screenlock.sh
+Restart=on-failure
+
+[Install]
+WantedBy=default.target

--- a/kousu-desktop/src/usr/libexec/kousu-desktop/drop-credentials-on-screenlock.sh
+++ b/kousu-desktop/src/usr/libexec/kousu-desktop/drop-credentials-on-screenlock.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Lock gpg-agent (and hence its keychain, pass(1), and other things built on it)
+# on GUI screen lock.
+
+
+debounce() {
+  DEBOUNCE_MS=${1:-500}
+
+  local last_state=""
+  local last_time=0
+
+  while read -r state; do
+    now=$(date +%s%3N)
+
+    if [[ "$state" == "$last_state" ]] && (( "$now" - "$last_time" < $DEBOUNCE_MS )); then
+      continue
+    fi
+
+    last_state="$state"
+    last_time="$now"
+
+    echo "$state"
+  done
+}
+
+
+watch_lock_session() {
+  # GNOME and KDE and their ilk also use DBUS and also *respond* to logind's lock signals
+  # but they don't *send* those lock signals
+
+  trap '[ -n "$(jobs -p)" ] && kill $(jobs -p)' EXIT
+
+  dbus-monitor --session \
+    "type='signal',interface='org.gnome.ScreenSaver',member='ActiveChanged'" \
+    "type='signal',interface='org.freedesktop.ScreenSaver',member='ActiveChanged'" \
+    "type='signal',interface='org.kde.screensaver',member='ActiveChanged'" \
+    "type='signal',interface='org.mate.ScreenSaver',member='ActiveChanged'" \
+    "type='signal',interface='org.cinnamon.ScreenSaver',member='ActiveChanged'" 2>/dev/null |
+  while read -r line; do
+    case "$line" in
+      "boolean true")
+        echo "lock-session"
+        ;;
+      # "boolean false")
+      #   echo "unlock"
+      #   ;;
+    esac
+  done
+}
+
+watch_lock_system() {
+  trap '[ -n "$(jobs -p)" ] && kill $(jobs -p)' EXIT
+  # logind; used by sway, niri, hyprland, also maybe some tty session managers too? etc;
+  #
+  # the tail is because there's some stray header lines at boot
+  dbus-monitor 2>/dev/null --system \
+    "type='signal',interface='org.freedesktop.login1.Session',member='Lock'" |
+  grep 'member=Lock' |
+  while read -r line; do
+    case "$line" in
+      *)
+        echo "lock-system"
+        ;;
+    esac
+  done
+}
+
+watch_lock() {
+  trap '[ -n "$(jobs -p)" ] && kill $(jobs -p)' EXIT
+  watch_lock_session & watch_lock_system &
+  wait
+}
+
+. /etc/profile
+echo SSH_AUTH_SOCK=$SSH_AUTH_SOCK
+
+watch_lock | debounce | while read state; do
+  if [ "$state" != "lock-system" ] && [ "$state" != "lock-session" ]; then continue; fi
+  echo "$state: locking credentialss" >&2
+  (set -x
+  ssh-add -D
+  gpg-connect-agent reloadagent /bye
+  # secret-tool lock ??
+  )
+done


### PR DESCRIPTION
Lock gpg-agent and ssh-agent when the screen locks.

Keys already time out after 45min addition to timing out keys (which I have set to 45m for both 

https://github.com/kousu/arch-conf/blob/6f9d7457d94e108ea660b32c310375b16254f65f/kousu-desktop/src/etc/skel/.gnupg/gpg-agent.conf#L6

https://github.com/kousu/arch-conf/blob/6f9d7457d94e108ea660b32c310375b16254f65f/kousu-base/src/etc/ssh/ssh_config.d/site.conf#L11

but on my _phone_ my keys timeout when my screen locks, and that feels safer. I want to reproduce this on my laptop.
